### PR TITLE
Switch authLevel return type to string

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,7 @@ export type RequestUser = {
   name: string;
   email: string;
   email_verified: boolean;
-  authLevel: number;
+  authLevel: string;
   team?: string;
 };
 
@@ -19,18 +19,18 @@ export type Team = {
 export const getCurrentUser = async (token: string, originalUrl: string): Promise<RequestUser> => {
   let res: string;
   try {
-    res =  await req.get(`${process.env.AUTH_URL}/api/v1/users/me`, {
+    res = await req.get(`${process.env.AUTH_URL}/api/v1/users/me`, {
       headers: {
         Authorization: token,
         Referer: originalUrl
       }
-    })
-  } catch (err) { 
+    });
+  } catch (err) {
     throw new Error(err);
   }
 
   const user = JSON.parse(res);
-  if (user.error && user.status >= 400 ) {
+  if (user.error && user.status >= 400) {
     throw new Error(user.error);
   }
 
@@ -48,7 +48,7 @@ export const getCurrentUser = async (token: string, originalUrl: string): Promis
 export const getAllUsers = async (token: string): Promise<RequestUser[]> => {
   let res;
   try {
-    res =  await req.get(`${process.env.AUTH_URL}/api/v1/users`, {
+    res = await req.get(`${process.env.AUTH_URL}/api/v1/users`, {
       headers: {
         Authorization: `${token}`
       }
@@ -56,9 +56,9 @@ export const getAllUsers = async (token: string): Promise<RequestUser[]> => {
   } catch (err) { throw err; }
 
   const users = JSON.parse(res);
-  if (users.error && users.status >= 400 ) { throw new Error(users.error); }
-  
-  return users.users.map( (user: any) => (
+  if (users.error && users.status >= 400) { throw new Error(users.error); }
+
+  return users.users.map((user: any) => (
     {
       authId: user._id,
       name: user.name,
@@ -80,7 +80,7 @@ export const putCurrentUser = async (name: string, token: string): Promise<void>
     }
   });
 
-  if (res.error && res.status >= 400 ) { throw res.error; }
+  if (res.error && res.status >= 400) { throw res.error; }
 }
 
 export const getTeams = async (token: string): Promise<Team[]> => {
@@ -94,22 +94,20 @@ export const getTeams = async (token: string): Promise<Team[]> => {
   } catch (err) { throw new Error(err); }
 
   const teams: any = JSON.parse(res);
-  if (teams.error && teams.status >= 400 ) { throw new Error(teams.error); }
+  if (teams.error && teams.status >= 400) { throw new Error(teams.error); }
 
-  return teams.map( (team: any) => (
-    {
-      _id: team.team._id,
-      name: team.team.name,
-      creator: team.team.creator,
-      table_no: team.team.table_no
-    }
-  ))
+  return teams.map((team: any) => ({
+    _id: team.team._id,
+    name: team.team.name,
+    creator: team.team.creator,
+    table_no: team.team.table_no
+  }));
 }
 
 export const getTeam = async (token: string, teamCode: string): Promise<Team> => {
   const allTeams: Team[] = await getTeams(token);
 
-  const team: Team | undefined = allTeams.find( team => team._id === teamCode)
+  const team: Team | undefined = allTeams.find(team => team._id === teamCode)
 
   if (team === undefined) {
     throw new Error("Team not found")


### PR DESCRIPTION
hs_auth now uses strings to represent the auth levels, so added support to convert from strings to the AuthLevel enum

Fixed some formatting errors to make it more consistent